### PR TITLE
feat(header): Add generic license header

### DIFF
--- a/resources/headers/license.php
+++ b/resources/headers/license.php
@@ -1,0 +1,9 @@
+<?php
+return <<<HEADER
+This file is part of Coffreo project "$composer->name"
+
+(c) Coffreo SAS <contact@coffreo.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+HEADER;


### PR DESCRIPTION
This header don't set the license type, it just indicate that license is located
in LICENSE file at project root.