### PR TITLE
fix(rules): disable risky rule mb_str_functions on PHP7.x

### DIFF
--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -40,7 +40,7 @@ final class Php70 extends AbstractRuleSet
         ],
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
-        'mb_str_functions' => true,
+        'mb_str_functions' => false,
         'modernize_types_casting' => true,
         'native_function_invocation' => true,
         'no_alias_functions' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -42,7 +42,7 @@ final class Php71 extends AbstractRuleSet
         'list_syntax' => [
             'syntax' => 'short',
         ],
-        'mb_str_functions' => true,
+        'mb_str_functions' => false,
         'modernize_types_casting' => true,
         'native_function_invocation' => true,
         'no_alias_functions' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -42,7 +42,7 @@ final class Php72 extends AbstractRuleSet
         'list_syntax' => [
             'syntax' => 'short',
         ],
-        'mb_str_functions' => true,
+        'mb_str_functions' => false,
         'modernize_types_casting' => true,
         'native_function_invocation' => true,
         'no_alias_functions' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -57,7 +57,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             ],
             'linebreak_after_opening_tag' => true,
             'list_syntax' => false,
-            'mb_str_functions' => true,
+            'mb_str_functions' => false,
             'modernize_types_casting' => true,
             'native_function_invocation' => true,
             'no_alias_functions' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -59,7 +59,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'list_syntax' => [
                 'syntax' => 'short',
             ],
-            'mb_str_functions' => true,
+            'mb_str_functions' => false,
             'modernize_types_casting' => true,
             'native_function_invocation' => true,
             'no_alias_functions' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -59,7 +59,7 @@ final class Php72Test extends AbstractRuleSetTestCase
             'list_syntax' => [
                 'syntax' => 'short',
             ],
-            'mb_str_functions' => true,
+            'mb_str_functions' => false,
             'modernize_types_casting' => true,
             'native_function_invocation' => true,
             'no_alias_functions' => true,


### PR DESCRIPTION
Closes #9